### PR TITLE
Fix link from 1.16 entries to awards

### DIFF
--- a/1.16/entries/index.html
+++ b/1.16/entries/index.html
@@ -34,7 +34,7 @@
 			<a class="navbar-item" href="">
 				Entries
 			</a>
-			<a class="navbar-item" href="/awards">
+			<a class="navbar-item" href="./awards">
 				Awards
 			</a>
 			<a class="navbar-item" href="../pack">


### PR DESCRIPTION
This was sending users to https://modfest.net/awards instead of https://modfest.net/1.16/entries/awards